### PR TITLE
improve init_github_actions()

### DIFF
--- a/R/init_github_actions.R
+++ b/R/init_github_actions.R
@@ -7,9 +7,20 @@ init_github_actions <- function() {
 
   if (check_project_status()) {
     usethis::use_github_action(
-      url = "https://raw.githubusercontent.com/Gilead-BioStats/qcthat/updates/inst/template/qualification_report.yaml?token=GHSAT0AAAAAAB73423OEWAILD2UG6GQLTCMZN5B4MA",
+      url = "https://raw.githubusercontent.com/Gilead-BioStats/gsm/dev/.github/workflows/qualification-report.yaml",
       save_as = "qualification_report.yaml"
       )
+
+    github_actions_path <- paste0(usethis::proj_path(), "/.github/workflows")
+
+    invisible(
+      file.copy(
+        from = system.file("template", "qualification_report.yaml", package = "qcthat"),
+        to = paste0(github_actions_path, "/qualification_report.yaml"),
+        overwrite = TRUE
+      )
+    )
+
   }
 
 }


### PR DESCRIPTION
Fix #10 

This will be more straightforward once the repository is open-source. 

For now - uses `usethis::use_github_actions()` to initialize the directory structure, and add file extensions to `.ignore`. Then uses the `.yaml` file in `inst/template` to create a simple reporting workflow. 