### PR TITLE
Missing `results` and issue counts

### DIFF
--- a/R/CompileTestResults.R
+++ b/R/CompileTestResults.R
@@ -110,21 +110,29 @@ CompileDispositions <- function(lTestResults) {
 #' @returns The string `"pass"`, `"fail"`, or `"skip"`.
 #' @keywords internal
 ExtractDisposition <- function(lTestResult) {
-  classes <- unlist(purrr::map(lTestResult$results, class))
-  classes <- setdiff(classes, c("expectation", "condition", "error"))
-  if (identical(classes, "expectation_success")) {
-    return("pass")
-  } else if ("expectation_failure" %in% classes) {
-    return("fail")
-  } else if ("expectation_skip" %in% classes) {
-    return("skip")
-  } else if ("expectation_warning" %in% classes) {
-    return("fail")
+  if (length(lTestResult$results)) {
+    classes <- unlist(purrr::map(lTestResult$results, class))
+    classes <- setdiff(classes, c("expectation", "condition", "error"))
+    if (identical(classes, "expectation_success")) {
+      return("pass")
+    } else if ("expectation_failure" %in% classes) {
+      return("fail")
+    } else if ("expectation_skip" %in% classes) {
+      return("skip")
+    } else if ("expectation_warning" %in% classes) {
+      return("fail")
+    }
+    cli::cli_abort(
+      "Unexpected result classes: {.val {classes}}",
+      class = "qcthat-error-unexpected_result_class"
+    )
   }
   cli::cli_abort(
     c(
-      "Unexpected result classes: {.val {classes}}"
+      "No test results found.",
+      i = "You may need to rerun tests with a different {.arg reporter}.",
+      i = "We recommend the {.str silent} reporter."
     ),
-    class = "qcthat-error-unexpected_result_class"
+    class = "qcthat-error-missing_results"
   )
 }

--- a/R/FetchRepoIssues.R
+++ b/R/FetchRepoIssues.R
@@ -65,7 +65,8 @@ FetchRawRepoIssues <- function(
     owner = strOwner,
     repo = strRepo,
     state = "all",
-    .token = strGHToken
+    .token = strGHToken,
+    .limit = Inf
   )
   # nocov end
 }

--- a/tests/testthat/_snaps/CompileTestResults.md
+++ b/tests/testthat/_snaps/CompileTestResults.md
@@ -15,3 +15,13 @@
       Error in `ExtractDisposition()`:
       ! Unexpected result classes: "some_weird_class"
 
+# ExtractDisposition() helper errors informatively for missing results within lTestResult object
+
+    Code
+      ExtractDisposition(lTestResult)
+    Condition
+      Error in `ExtractDisposition()`:
+      ! No test results found.
+      i You may need to rerun tests with a different `reporter`.
+      i We recommend the "silent" reporter.
+

--- a/tests/testthat/test-CompileTestResults.R
+++ b/tests/testthat/test-CompileTestResults.R
@@ -95,3 +95,19 @@ test_that("ExtractDisposition() helper errors informatively for weird results", 
     error = TRUE
   )
 })
+
+test_that("ExtractDisposition() helper errors informatively for missing results within lTestResult object", {
+  lTestResult <- list(
+    results = list()
+  )
+  expect_error(
+    {
+      ExtractDisposition(lTestResult)
+    },
+    class = "qcthat-error-missing_results"
+  )
+  expect_snapshot(
+    ExtractDisposition(lTestResult),
+    error = TRUE
+  )
+})


### PR DESCRIPTION
Added error message for missing testthat `results` field, explaining how to make sure your tests object contains the results. We can modify this message as part of #44.

Also added `.limit = Inf` in GitHub API call to make sure we get all of the issues.

- Closes #45
- Closes #47