### PR TITLE
Verify reports work for releases

### DIFF
--- a/tests/testthat/test-AttachReleaseReports.R
+++ b/tests/testthat/test-AttachReleaseReports.R
@@ -144,7 +144,7 @@ test_that("CompileReleaseReportsMarkdown stitches together parts for releases (#
 test_that("AttachReleaseReports runs properly on release (#181)", {
   ExpectUserAccepts(
     "AttachReleaseReports attaches reports to published releases",
-    181,
+    intIssue = 181,
     chrInstructions = "Navigate to [this release](https://github.com/Gilead-BioStats/qcthat/releases/tag/ForTesting)",
     chrChecks = c(
       "The release has a section titled 'qcthat Reports'",


### PR DESCRIPTION
## Overview
Add UAT for `qcthat.yaml` with releases.

## Test Notes/Sample Code
This will also confirm that the UAT management still runs properly via the action.

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #181.
