### PR TITLE
Fix 247: Allow namespacing of `test_that()`

### DIFF
--- a/R/ExtractTestsFromFiles.R
+++ b/R/ExtractTestsFromFiles.R
@@ -82,7 +82,10 @@ ExtractTestsFromFile <- function(strFilePath, envCall = rlang::caller_env()) {
 #' @returns A list of lists, each containing `desc`, `start`, and `end`.
 #' @keywords internal
 FindTests <- function(chrTestLines) {
-  intTestStarts <- stringr::str_which(chrTestLines, "^\\s*test_that\\(")
+  intTestStarts <- stringr::str_which(
+    chrTestLines,
+    "^\\s*(testthat::)?test_that\\("
+  )
   if (!length(intTestStarts)) {
     return(vctrs::list_of(.ptype = integer()))
   }
@@ -110,7 +113,9 @@ ParseTest <- function(chrTestLines, intTestStart) {
     return(NULL)
   }
   exprCall <- exprParsed[[1]]
-  if (!rlang::is_call(exprCall, "test_that")) {
+  is_test_that <- rlang::is_call(exprCall, "test_that") ||
+    identical(deparse(exprCall[[1]]), "testthat::test_that")
+  if (!is_test_that) {
     return(NULL)
   }
   strDesc <- tryCatch(

--- a/tests/testthat/.gitignore
+++ b/tests/testthat/.gitignore
@@ -1,0 +1,1 @@
+_problems

--- a/tests/testthat/test-ExtractTestsFromFiles.R
+++ b/tests/testthat/test-ExtractTestsFromFiles.R
@@ -43,6 +43,20 @@ test_that("ExtractTestsFromFiles returns an empty tibble with the expected shape
   expect_identical(dfResult, dfExpected)
 })
 
+test_that("FindTests finds tests using testthat:: namespace prefix (#247)", {
+  chrLines <- c(
+    "# comment",
+    'testthat::test_that("Test with namespace prefix (#247)", {',
+    "  expect_true(TRUE)",
+    "})"
+  )
+  lResult <- FindTests(chrLines)
+  expect_length(lResult, 1L)
+  expect_equal(lResult[[1]]$Test, "Test with namespace prefix (#247)")
+  expect_equal(lResult[[1]]$LineStart, 2L)
+  expect_equal(lResult[[1]]$LineEnd, 4L)
+})
+
 test_that("ParseTest handles corner cases (#noissue)", {
   expect_null(
     ParseTest(


### PR DESCRIPTION
## Overview
Include `testthat::test_that()` tests in the test extraction (in addition to `test_that()` without namespace).

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #247.
