### PR TITLE
Fix 306: Warn on missing milestone

### DIFF
--- a/.github/workflows/qcthat.yaml
+++ b/.github/workflows/qcthat.yaml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v6
+        uses: gilead-biostats/gsm.utils/checkout@actions-v1
 
       - name: Install R and dependencies
         uses: gilead-biostats/gsm.utils/install@actions-v1

--- a/R/QCReports.R
+++ b/R/QCReports.R
@@ -196,20 +196,10 @@ QCMilestones <- function(
     )
   chrMissingMilestones <- chrMilestones[!chrMilestones %in% dfITM$Milestone]
   if (length(chrMissingMilestones)) {
-    if (length(chrMissingMilestones) == length(chrMilestones)) {
-      qcthatAbort(
-        c(
-          "{.arg chrMilestones} must refer to at least one milestone in the issue-test matrix.",
-          i = "Unknown milestones: {chrMissingMilestones}"
-        ),
-        strErrorSubclass = "unknown_milestones",
-        envCall = envCall
-      )
-    }
     if (lglWarn) {
       cli::cli_warn(
         c(
-          "Some {.arg chrMilestones} are not in the issue-test matrix.",
+          "{cli::qty(chrMissingMilestones)} {?One/Some} {.arg chrMilestone{?s}} {?is/are} not in the issue-test matrix.",
           i = "Unknown milestones: {chrMissingMilestones}"
         ),
         class = CompileConditionClasses("unknown_milestones", "warning"),

--- a/R/QCReports.R
+++ b/R/QCReports.R
@@ -199,7 +199,7 @@ QCMilestones <- function(
     if (lglWarn) {
       cli::cli_warn(
         c(
-          "{cli::qty(chrMissingMilestones)} {?One/Some} {.arg chrMilestone{?s}} {?is/are} not in the issue-test matrix.",
+          "{cli::qty(chrMissingMilestones)} {?One element of/Some elements of} {.arg chrMilestone} {?is/are} not in the issue-test matrix.",
           i = "Unknown milestones: {chrMissingMilestones}"
         ),
         class = CompileConditionClasses("unknown_milestones", "warning"),

--- a/tests/testthat/test-QCReports.R
+++ b/tests/testthat/test-QCReports.R
@@ -167,7 +167,7 @@ test_that("QCMilestones warns about unknown milestones (#88)", {
   expect_identical(test_result, expected_result)
 })
 
-test_that("QCMilestones errors with no valid milestones (#88)", {
+test_that("QCMilestones warns with no valid milestones (#88, #306)", {
   local_mocked_bindings(
     QCPackage = function(...) {
       tibble::tibble(
@@ -178,9 +178,9 @@ test_that("QCMilestones errors with no valid milestones (#88)", {
       )
     }
   )
-  expect_error(
+  expect_warning(
     QCMilestones("C"),
     "Unknown milestones: C",
-    class = "qcthat-error-unknown_milestones"
+    class = "qcthat-warning-unknown_milestones"
   )
 })


### PR DESCRIPTION
## Overview
Update `QCMilestones()` to *warn* (rather than error) when the milestones are missing.

## Test Notes/Sample Code
I did a minor update to the workflow, but I'll do a full update in a separate PR soonish. I want to keep this focused on the one issue.

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #306
