### PR TITLE
Change 'gh' remote reference to r-lib/gh

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gh=jharmon-gilead/gh@fix-231-ghs-tokens
+    gh=r-lib/gh
 Config/Needs/website: here, quarto, rmarkdown
 Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3


### PR DESCRIPTION
## Overview
Updated remote repository reference for 'gh' package.

## Test Notes/Sample Code
Merging directly if possible to make qcthat work (its dependency doesn't exist right now).

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->